### PR TITLE
Fix transaction dates and date rendering for Vanguard reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,10 @@ This tool outputs information on asset disposals, which help in the calculation 
 
 ## TODO
 
-* Add ~~unit tests~~, **full** coverage, ~~linting~~ - WIP
-* ~~Facilitate multiple input formats (e.g. Vanguard GIA report)~~
+* Full coverage
 * Reduce ambiguity over "total" being net of fees...
   * ...or allow trade to take either proceeds XOR total
-* Allow date formatting only, i.e. YYYY-MM-DD when the input format omits it, e.g. VanguardGIA
+* Additional input formats as required
 
 ## Limitations
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ const config = {
   collectCoverage: true,
   collectCoverageFrom: [
     '**/*.js',
-    '!btc-cgt.js',
+    '!cli.js',
     '!jest.config.js',
     '!tests/**/*.js',
     '!coverage/**/*.js',

--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -1,4 +1,4 @@
-exports.formatDate = (date = new Date()) => {
+const format = (date = new Date()) => {
   const formatter = new Intl.DateTimeFormat('en-GB', {
     month: 'short',
     day: '2-digit',
@@ -9,5 +9,11 @@ exports.formatDate = (date = new Date()) => {
   });
 
   // "Dec 21, 13:01" → remove the comma
-  return formatter.format(date).replace(',', ' at');
+  return formatter.format(date);
 };
+
+exports.formatDate = (d) => format(d)
+  .replace(',', ' at');
+
+exports.formatDateOnly = (d) => format(d)
+  .replace(/,.*$/, '');

--- a/lib/input-format/vanguard-gia.js
+++ b/lib/input-format/vanguard-gia.js
@@ -170,6 +170,7 @@ class VanguardGIA {
       thisAsset.trades.push({
         id: v4(),
         date: cashRecordDate,
+        dateOnly: true, // This format lacks HH:MM:SS
         type,
         qty: toBigAbs(ir.Quantity),
         total,

--- a/lib/input-format/vanguard-gia.js
+++ b/lib/input-format/vanguard-gia.js
@@ -93,8 +93,10 @@ class VanguardGIA {
     VanguardGIA.assertOrdered(cashRecords);
     VanguardGIA.assertOrdered(investmentRecords);
 
-    const cashFeesOnly = cashRecords
-      .filter((r) => r.Details.startsWith('ETF dealing fee'))
+    const cashRecordsOfInterest = cashRecords
+      .filter((r) => r.Details.startsWith('ETF dealing fee')
+        || r.Details.startsWith('Bought')
+        || r.Details.startsWith('Sold'))
       .map((r) => ({
         ...r,
         matchedWithInvestment: false,
@@ -115,7 +117,7 @@ class VanguardGIA {
       const assetName = ir.InvestmentName;
       if (!byAsset.has(assetName)) {
         byAsset.set(assetName, {
-          asset: new Unit(assetName), // TODO: link up name here
+          asset: new Unit(assetName),
           currency: GBP,
           trades: [],
         });
@@ -124,21 +126,39 @@ class VanguardGIA {
       const thisAsset = byAsset.get(assetName);
       const investmentRecordDate = VanguardGIA.toDate(ir.Date);
       // if there is an associated fee what would it look like?
-      const feeDetails = `ETF dealing fee (${type.toLowerCase()}) ${assetName}`;
-      const matchingFee = cashFeesOnly.find((f) => !f.matchedWithInvestment
-        && f.Details === feeDetails
-        && daysBetween(VanguardGIA.toDate(f.Date), investmentRecordDate) < 7);
+      const matchingCashRecordIndex = cashRecordsOfInterest
+        .findIndex((r) => !r.matchedWithInvestment
+          && r.Details === details);
       debug(
-        'Searching for a fee week prior to %s with Details "%s", found? %s',
-        investmentRecordDate,
-        feeDetails,
-        matchingFee || false
+        'Searching for first unmatched cash record with details="%s"',
+        details
       );
+      assert(matchingCashRecordIndex !== -1, 'Could not find matching cash record, use DEBUG=s104:input for details');
+      const matchingCashRecord = cashRecordsOfInterest.at(matchingCashRecordIndex);
+      // avoid matching again
+      matchingCashRecord.matchedWithInvestment = true;
+      const cashRecordDate = VanguardGIA.toDate(matchingCashRecord.Date);
+
+      // check for a fee in the next row
+      const maybeFee = cashRecordsOfInterest.at(matchingCashRecordIndex + 1);
+      const feeDetails = `ETF dealing fee (${type.toLowerCase()}) ${assetName}`;
+
       const toBigAbs = (given) => new Big(given.replace(/,/g, '')).abs();
+
       let fee;
-      if (matchingFee) {
-        matchingFee.matchedWithInvestment = true;
-        fee = toBigAbs(matchingFee.Amount);
+      if (maybeFee && maybeFee.Details === feeDetails) {
+        // our logic makes a few assumptions here, assert as much
+        debug('Found a fee in the index following the cash record:', maybeFee);
+        assert(!maybeFee.matchedWithInvestment, 'Fee already matched, failed assumption');
+        debug('Date of cash record: %s', maybeFee.Date);
+        debug('Date of investment record: %s', ir.Date);
+        assert(
+          daysBetween(VanguardGIA.toDate(maybeFee.Date), investmentRecordDate) < 7,
+          'Fee settled 7 or more days after cash record, unlikely to be a true match'
+        );
+
+        maybeFee.matchedWithInvestment = true;
+        fee = toBigAbs(maybeFee.Amount);
       } else {
         fee = ZERO;
       }
@@ -149,8 +169,7 @@ class VanguardGIA {
         : toBigAbs(ir.Cost).minus(fee);
       thisAsset.trades.push({
         id: v4(),
-        // TODO: I think this is settlement date, not actual transaction date
-        date: investmentRecordDate,
+        date: cashRecordDate,
         type,
         qty: toBigAbs(ir.Quantity),
         total,
@@ -159,6 +178,13 @@ class VanguardGIA {
         raw: ir,
       });
     });
+
+    const unmatchedRecords = cashRecordsOfInterest.filter((r) => !r.matchedWithInvestment);
+    debug('Cash records unmatched with investment records:', unmatchedRecords);
+    assert(
+      !unmatchedRecords.length,
+      'There were unmatched cash records. Use DEBUG=s104:input for more details'
+    );
 
     return Array.from(byAsset.values());
   }

--- a/lib/trade-processor.js
+++ b/lib/trade-processor.js
@@ -5,6 +5,7 @@ const {
 } = require('./validation');
 const {
   formatDate,
+  formatDateOnly,
 } = require('./formatters');
 const {
   log,
@@ -162,8 +163,11 @@ class TradeProcessor {
     // ===== PROCESS TRADES =====
     for (let i = 0; i < trades.length; i++) {
       const t = trades[i];
+      const dateFormatter = t.dateOnly
+        ? formatDateOnly
+        : formatDate;
 
-      log(`On ${formatDate(t.date)} I ${t.description}`);
+      log(`On ${dateFormatter(t.date)} I ${t.description}`);
 
       if (t.type === 'SELL') {
         // add to the fee straightaway
@@ -210,7 +214,7 @@ class TradeProcessor {
             log(
               '%s matched with the buy on %s',
               this.asset.formatAmountWithUnit(matchQty),
-              formatDate(b.date)
+              dateFormatter(b.date)
             );
 
             // disposalProceeds already has fee removed

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -28,6 +28,9 @@ exports.isValidTrade = (given) => {
   if (!isBig(given.fee) || !given.fee.gte(ZERO)) {
     return fail('given.fee must be a non-negative Big');
   }
+  if (!['undefined', 'boolean'].includes(typeof given.dateOnly)) {
+    return fail('given.dateOnly must be a boolean if provided');
+  }
   if (!isBig(given.total) || given.total.eq(ZERO)) {
     return fail(`given.total must be a non-zero Big, got ${given.total}`);
   }

--- a/tests/lib/trade-processor.spec.js
+++ b/tests/lib/trade-processor.spec.js
@@ -85,35 +85,37 @@ describe('TradeProcessor', () => {
       expect(cost.eq(new Big('12000'))).toBe(true); // not part of example
     });
 
+    const example2Trades = [{
+      id: '#1',
+      type: 'BUY',
+      date: new Date('2020-03-01T09:00:00.000Z'),
+      description: 'Bought 9500 shares in Mesopotamia plc',
+      qty: new Big('9500'),
+      fee: ZERO,
+      total: new Big('9500'), // we do not know this figure
+      raw: {},
+    }, {
+      id: '#2',
+      type: 'SELL',
+      date: new Date('2020-08-30T09:00:00.000Z'),
+      description: 'Sold 4000 shares in Mesopotamia plc',
+      qty: new Big('4000'),
+      fee: ZERO,
+      total: new Big('6000'),
+      raw: {},
+    }, {
+      id: '#3',
+      type: 'BUY',
+      date: new Date('2020-09-11T09:00:00.000Z'),
+      description: 'Bought 500 shares in Mesopotamia plc',
+      qty: new Big('500'),
+      fee: ZERO,
+      total: new Big('850'),
+      raw: {},
+    }];
+
     it('should follow example 2', () => {
-      const trades = [{
-        id: '#1',
-        type: 'BUY',
-        date: new Date('2020-03-01T09:00:00.000Z'),
-        description: 'Bought 9500 shares in Mesopotamia plc',
-        qty: new Big('9500'),
-        fee: ZERO,
-        total: new Big('9500'), // we do not know this figure
-        raw: {},
-      }, {
-        id: '#2',
-        type: 'SELL',
-        date: new Date('2020-08-30T09:00:00.000Z'),
-        description: 'Sold 4000 shares in Mesopotamia plc',
-        qty: new Big('4000'),
-        fee: ZERO,
-        total: new Big('6000'),
-        raw: {},
-      }, {
-        id: '#3',
-        type: 'BUY',
-        date: new Date('2020-09-11T09:00:00.000Z'),
-        description: 'Bought 500 shares in Mesopotamia plc',
-        qty: new Big('500'),
-        fee: ZERO,
-        total: new Big('850'),
-        raw: {},
-      }];
+      const trades = example2Trades;
 
       const tp = new TradeProcessor({
         asset: new Share('Mesopotamia plc'),
@@ -140,6 +142,20 @@ describe('TradeProcessor', () => {
       expect(proceeds.eq('6000')).toBe(true);
       expect(qty.eq('4000')).toBe(true);
       expect(toString()).toBe('2020-08-30 | Sold 4000 shares | Gain/Loss £1650.00');
+    });
+
+    it('should support dateOnly being provided on trades - example 2', () => {
+      const tradesDateOnly = example2Trades.map((t) => ({
+        ...t,
+        dateOnly: true,
+      }));
+
+      const tp = new TradeProcessor({
+        asset: new Share('Mesopotamia plc'),
+        currency: GBP,
+      });
+
+      tp.process(tradesDateOnly);
     });
 
     const example3Trades = [{
@@ -235,6 +251,20 @@ describe('TradeProcessor', () => {
       expect(gain.toFixed(0)).toBe('300');
       expect(proceeds.toFixed(0)).toBe('1975');
       expect(qty.toFixed(0)).toBe('400');
+    });
+
+    it('should support dateOnly being provided on trades - example 3', () => {
+      const tradesDateOnly = example3Trades.map((t) => ({
+        ...t,
+        dateOnly: true,
+      }));
+
+      const tp = new TradeProcessor({
+        asset: new Share('Lobster plc'),
+        currency: GBP,
+      });
+
+      tp.process(tradesDateOnly);
     });
   }); // examples
 

--- a/tests/lib/validation.spec.js
+++ b/tests/lib/validation.spec.js
@@ -60,6 +60,10 @@ describe('validation', () => {
     }, {
       type: 'SELL',
     }, {
+      dateOnly: true,
+    }, {
+      dateOnly: false,
+    }, {
       raw: {
         a: 'whatever',
         b: 'we',
@@ -96,6 +100,10 @@ describe('validation', () => {
       date: 'today',
     }, {
       date: new Date('foobar'),
+    }, {
+      dateOnly: 1,
+    }, {
+      dateOnly: null,
     }, {
       qty: ZERO,
     }, {


### PR DESCRIPTION
Fixes #3 

Before and after:
```
--- vanguard-output-before.txt  2026-02-19 22:01:30
+++ /dev/fd/11  2026-02-19 23:04:23
@@ -1,12 +1,12 @@
 ===== POOL: Units of S&P 500 UCITS ETF - Distributing (VUSA) =====
-On 25 Oct 2024 at 13:00 I Bought XXX S&P 500 UCITS ETF - Distributing (VUSA)
+On 23 Oct 2024 I Bought XXX S&P 500 UCITS ETF - Distributing (VUSA)

 The section 104 holding is formed
```

The dates are now correct to the cash record rather than the investment record (likely settlement) date.

We never had time of day provided, so don't use midday UTC as stand-in. Omit it instead.